### PR TITLE
fix: remove version if exists in apt source

### DIFF
--- a/differs/apt_diff.go
+++ b/differs/apt_diff.go
@@ -85,19 +85,17 @@ func (a AptAnalyzer) parseLine(text string, currPackage string, packages map[str
 		case "Package":
 			return value
 		case "Source":
-			return value
+			return strings.Fields(value)[0]
 		case "Version":
 			if packages[currPackage].Version != "" {
 				logrus.Warningln("Multiple versions of same package detected.  Diffing such multi-versioning not yet supported.")
 				return currPackage
 			}
-			// TODO(snyk): make sure we want this modification
-			modifiedValue := strings.Replace(value, "+", " ", 1)
 			currPackageInfo, ok := packages[currPackage]
 			if !ok {
 				currPackageInfo = util.PackageInfo{}
 			}
-			currPackageInfo.Version = modifiedValue
+			currPackageInfo.Version = value
 			packages[currPackage] = currPackageInfo
 			return currPackage
 		default:

--- a/differs/apt_diff_test.go
+++ b/differs/apt_diff_test.go
@@ -62,7 +62,7 @@ func TestParseLine(t *testing.T) {
 			packages:    map[string]util.PackageInfo{},
 			currPackage: "La-Croix",
 			expPackage:  "La-Croix",
-			expected:    map[string]util.PackageInfo{"La-Croix": {Version: "Lime extra_lime"}},
+			expected:    map[string]util.PackageInfo{"La-Croix": {Version: "Lime+extra_lime"}},
 		},
 		{
 			descrip:     "Size line is ignored (vs original container-diff behaviours)",
@@ -124,9 +124,10 @@ func TestGetAptPackages(t *testing.T) {
 			descrip: "packages in expected location",
 			path:    "testDirs/packageOne",
 			expected: map[string]util.PackageInfo{
-				"pac1":   {Version: "1.0"},
-				"pac2":   {Version: "2.0"},
-				"pac_ng": {Version: "3.0"}},
+				"pac1":    {Version: "1.0"},
+				"pac2":    {Version: "2.0"},
+				"pac_ng":  {Version: "3.0"},
+				"pac4_ng": {Version: "1:2.29.2-1+deb9u1"}},
 		},
 	}
 	for _, test := range testCases {

--- a/differs/testDirs/packageOne/var/lib/dpkg/status
+++ b/differs/testDirs/packageOne/var/lib/dpkg/status
@@ -12,3 +12,9 @@ Installed-Size: 123
 Source: pac_ng
 Version: 3.0
 info: again other stuff
+
+Package: pac4
+Installed-Size: 238
+Source: pac4_ng (2.29.2-1+deb9u1)
+Version: 1:2.29.2-1+deb9u1
+info: again other stuff


### PR DESCRIPTION
Removed version from package name and kept the + sign in the package version. 