### PR TITLE
Fix: apk version update

### DIFF
--- a/differs/apk_diff.go
+++ b/differs/apk_diff.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	pkgutil "github.com/snyk/snyk-docker-analyzer/pkg/util"
@@ -95,22 +94,6 @@ func (a ApkAnalyzer) parseLine(text string, currPackage string, packages map[str
 				currPackageInfo = util.PackageInfo{}
 			}
 			currPackageInfo.Version = value
-			packages[currPackage] = currPackageInfo
-			return currPackage
-
-		case "I":
-			currPackageInfo, ok := packages[currPackage]
-			if !ok {
-				currPackageInfo = util.PackageInfo{}
-			}
-			var size int64
-			var err error
-			size, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				logrus.Errorf("Could not get size for %s: %s", currPackage, err)
-				size = -1
-			}
-			currPackageInfo.Size = size
 			packages[currPackage] = currPackageInfo
 			return currPackage
 		default:

--- a/differs/apk_diff_test.go
+++ b/differs/apk_diff_test.go
@@ -101,8 +101,7 @@ func TestGetApkPackages(t *testing.T) {
 			path:    "testDirs/packageOne",
 			expected: map[string]util.PackageInfo{
 				"pac1": {Version: "1.0"},
-				"pac2": {Version: "2.0"},
-				"pac3": {Version: "3.0"}},
+				"pac2": {Version: "2.0"}},
 		},
 	}
 	for _, test := range testCases {

--- a/differs/testDirs/packageMulti/lib/apk/db/installed
+++ b/differs/testDirs/packageMulti/lib/apk/db/installed
@@ -4,8 +4,9 @@ Info:other stuff
 
 P:pac2
 V:2.0
-Info:again other stuff
-
-P:pac3
-V:3.0
-Info:again other stuff
+A:x86_64
+S:357083
+I:581632
+T:the musl c library (libc) implementation
+U:http://www.musl-libc.org/
+L:MIT

--- a/differs/testDirs/packageOne/lib/apk/db/installed
+++ b/differs/testDirs/packageOne/lib/apk/db/installed
@@ -4,8 +4,9 @@ Info:other stuff
 
 P:pac2
 V:2.0
-Info:again other stuff
-
-P:pac3
-V:3.0
-Info:again other stuff
+A:x86_64
+S:357083
+I:581632
+T:the musl c library (libc) implementation
+U:http://www.musl-libc.org/
+L:MIT


### PR DESCRIPTION
Add tests to APK analyzer and keep the same version as defined in the apk installed file.