### PR TITLE
fix: untar all files with at-least RW permissions

### DIFF
--- a/pkg/util/tar_utils.go
+++ b/pkg/util/tar_utils.go
@@ -64,6 +64,9 @@ func unpackTar(tr *tar.Reader, path string, whitelist []string) error {
 			continue
 		}
 		mode := header.FileInfo().Mode()
+		const CHMOD_RW_OWNER_R_ALL = 0644
+		const CHMOD_X_OWNER = 0100
+		mode = (mode & CHMOD_X_OWNER) | CHMOD_RW_OWNER_R_ALL
 		switch header.Typeflag {
 
 		// if its a dir and it doesn't exist create it


### PR DESCRIPTION
this fixes access-denied errors analyzing CentOS

`container-diff` currently has a similar open issue:  https://github.com/GoogleCloudPlatform/container-diff/issues/168 