### PR TITLE
feat: output also the scanned image ID

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -72,6 +72,8 @@ func analyzeImage(imageName string, analyzerArgs []string) error {
 	}
 
 	image, err := prepper.GetImage()
+	imageID := image.Config.Config.ImageID
+	output.PrintToStdErr("Image ID: %s\n", imageID)
 
 	if !save {
 		defer pkgutil.CleanupImage(image)
@@ -84,7 +86,7 @@ func analyzeImage(imageName string, analyzerArgs []string) error {
 	if err != nil {
 		return err
 	}
-	output.PrintToStdErr("OS release detected: %s", osRelease)
+	output.PrintToStdErr("OS release detected: %s\n", osRelease)
 
 	req := differs.SingleRequest{
 		Image:        image,
@@ -94,8 +96,8 @@ func analyzeImage(imageName string, analyzerArgs []string) error {
 		return fmt.Errorf("Error performing image analysis: %s", err)
 	}
 
-	output.PrintToStdErr("Retrieving analyses")
-	outputResults(analyses, osRelease)
+	output.PrintToStdErr("Retrieving analyses\n")
+	outputResults(imageID, osRelease, analyses)
 
 	if save {
 		logrus.Infof("Image was saved at %s", image.FSPath)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ var RootCmd = &cobra.Command{
 	},
 }
 
-func outputResults(resultMap map[string]util.Result, osRelease pkgutil.OSRelease) {
+func outputResults(imageID string, osRelease pkgutil.OSRelease, resultMap map[string]util.Result) {
 	// Outputs diff/analysis results in alphabetical order by analyzer name
 	sortedTypes := []string{}
 	for analyzerType := range resultMap {
@@ -72,6 +72,7 @@ func outputResults(resultMap map[string]util.Result, osRelease pkgutil.OSRelease
 		results[i] = result.OutputStruct()
 	}
 	output := map[string]interface{}{
+		"imageID":   imageID,
 		"osRelease": osRelease,
 		"results":   results,
 	}

--- a/pkg/util/image_prep_utils.go
+++ b/pkg/util/image_prep_utils.go
@@ -93,6 +93,7 @@ type ConfigObject struct {
 	Volumes      map[string]struct{} `json:"Volumes"`
 	Workdir      string              `json:"WorkingDir"`
 	Labels       map[string]string   `json:"Labels"`
+	ImageID      string              `json:"Image"`
 }
 
 type ConfigSchema struct {


### PR DESCRIPTION
I planned to be a good boy and add tests but there are currently no tests for relevant modified places (`analyzer.go`, `root.go`, `daemon_prepper.go`) - and with current priorities I think it's OK to approve it without tests 🙈 , as also the tests in `snyk-docker-plugin` will verify we get the ID.