### PR TITLE
fix: use config.digest from manifest as image id

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -72,8 +72,6 @@ func analyzeImage(imageName string, analyzerArgs []string) error {
 	}
 
 	image, err := prepper.GetImage()
-	imageID := image.Config.Config.ImageID
-	output.PrintToStdErr("Image ID: %s\n", imageID)
 
 	if !save {
 		defer pkgutil.CleanupImage(image)
@@ -97,7 +95,7 @@ func analyzeImage(imageName string, analyzerArgs []string) error {
 	}
 
 	output.PrintToStdErr("Retrieving analyses\n")
-	outputResults(imageID, osRelease, analyses)
+	outputResults(image.Id, osRelease, analyses)
 
 	if save {
 		logrus.Infof("Image was saved at %s", image.FSPath)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ var RootCmd = &cobra.Command{
 	},
 }
 
-func outputResults(imageID string, osRelease pkgutil.OSRelease, resultMap map[string]util.Result) {
+func outputResults(imageId string, osRelease pkgutil.OSRelease, resultMap map[string]util.Result) {
 	// Outputs diff/analysis results in alphabetical order by analyzer name
 	sortedTypes := []string{}
 	for analyzerType := range resultMap {
@@ -72,7 +72,7 @@ func outputResults(imageID string, osRelease pkgutil.OSRelease, resultMap map[st
 		results[i] = result.OutputStruct()
 	}
 	output := map[string]interface{}{
-		"imageID":   imageID,
+		"imageId":   imageId,
 		"osRelease": osRelease,
 		"results":   results,
 	}

--- a/pkg/util/cloud_prepper.go
+++ b/pkg/util/cloud_prepper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/image/docker"
 	"github.com/containers/image/types"
 	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
 )
 
 // CloudPrepper prepares images sourced from a Cloud registry
@@ -73,4 +74,8 @@ func (p *CloudPrepper) GetConfig() (ConfigSchema, error) {
 	}
 
 	return getConfigFromReference(ref, p.Source)
+}
+
+func (p *CloudPrepper) GetImageId() (string, error) {
+	return "", errors.New("TODO: Not implmenented")
 }

--- a/pkg/util/daemon_prepper.go
+++ b/pkg/util/daemon_prepper.go
@@ -91,3 +91,11 @@ func (p *DaemonPrepper) GetHistory() []ImageHistoryItem {
 	}
 	return historyItems
 }
+
+func (p *DaemonPrepper) GetImageId() (string, error) {
+	ref, err := daemon.ParseReference(p.Source)
+	if err != nil {
+		return "", err
+	}
+	return getImageIdFromReference(ref, p.Source)
+}

--- a/pkg/util/tar_prepper.go
+++ b/pkg/util/tar_prepper.go
@@ -101,3 +101,7 @@ func (p *TarPrepper) GetConfig() (ConfigSchema, error) {
 
 	return config, nil
 }
+
+func (p *TarPrepper) GetImageId() (string, error) {
+	return "", errors.New("TODO: Not implmenented")
+}


### PR DESCRIPTION
The method used previously in https://github.com/snyk/snyk-docker-analyzer/pull/15 was returning IDs different from what `docker inspect` & `docker images` show.

The method used here was manually tested to give the expected result and follows what's explained in: https://github.com/docker/distribution/issues/1662#issuecomment-213079540
